### PR TITLE
load script and randomize color immediately (no defer)

### DIFF
--- a/src/static/js/app.js
+++ b/src/static/js/app.js
@@ -43,13 +43,12 @@ function changeColor() {
   document.body.style.setProperty('--secondary-color', colorList[randomColor].color2)
 }
 
-window.onload = function(e){
-  // document.addEventListener('DOMContentLoaded', function(e) {
-    const btn = document.getElementById('colorpicker')
-    changeColor()
-    btn.addEventListener('click', function(){
-      changeColor()
-    })
-  }
-  console.log('Interested in speaking at our next event? Email hello@4front.io for details (:')
+// make this global -- run it immediately inside the <body>
+window.changeColor = changeColor;
 
+document.addEventListener('DOMContentLoaded', function(e) {
+  const btn = document.getElementById('colorpicker');
+  btn.addEventListener('click', changeColor);
+});
+
+console.log('Interested in speaking at our next event? Email hello@4front.io for details (:');

--- a/src/templates/_base.html
+++ b/src/templates/_base.html
@@ -25,10 +25,11 @@
         <meta name="twitter:image" content="">
 
         <link href="/static/css/app.css" rel="stylesheet">
-        <script src="/static/js/bundle.js" async defer></script>
+        <script src="/static/js/bundle.js"></script>
         {% include 'gtm_tag.html' %}
     </head>
     <body>
+        <script>if (window.changeColor) window.changeColor();</script>
         <!-- Google Tag Manager (noscript) -->
         <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9F7FZ2"
         height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
Proposing this fix to `changeColor` so that we run it as soon as the `<body>` is on the page. This stops the flash of default styles from showing since it updates the CSS vars before the page has loaded.

Summary of changes:
- remove `async` and `defer` attributes from bundled JS (if the file grows large enough that load time is a concern we can put these back in, but right now it's miniscule)
- explicitly make `changeColor` a global in order to call it from the base template
- change `window.onload` to `DOMContentLoaded` in JS (should be a smidge faster)